### PR TITLE
Allow either moxi_works_agent_id or agent_uuid when searching contacts

### DIFF
--- a/lib/moxiworks_platform/contact.rb
+++ b/lib/moxiworks_platform/contact.rb
@@ -515,7 +515,8 @@ module MoxiworksPlatform
 
     # Search an Agent's Contacts in Moxi Works Platform
     # @param [Hash] opts named parameter Hash
-    # @option opts [String]  :moxi_works_agent_id *REQUIRED* The Moxi Works Agent ID for the agent to which this contact is associated
+    # @option opts [String]  :moxi_works_agent_id  *REQUIRED* -- either :moxi_works_agent_id or :agent_uuid is required -- The Moxi Works Agent ID for the agent
+    # @option opts [String]  :agent_uuid *REQUIRED* -- either :moxi_works_agent_id or :agent_uuid is required -- The Moxi Works Agent ID for the agent
     #
     #     optional Search parameters
     #
@@ -537,11 +538,9 @@ module MoxiworksPlatform
     #
     def self.search(opts={})
       url ||= "#{MoxiworksPlatform::Config.url}/api/contacts"
-      required_opts = [:moxi_works_agent_id]
-      required_opts.each do |opt|
-        raise ::MoxiworksPlatform::Exception::ArgumentError, "#{opt} required" if
-            opts[opt].nil? or opts[opt].to_s.empty?
-      end
+      agent_identifier = opts[:moxi_works_agent_id] || opts[:agent_uuid]
+      raise ::MoxiworksPlatform::Exception::ArgumentError, "#agent_uuid or moxi_works_agent_id required" if
+        agent_identifier.nil?
       results = MoxiResponseArray.new()
       RestClient::Request.execute(method: :get,
                                   url: url,

--- a/lib/moxiworks_platform/version.rb
+++ b/lib/moxiworks_platform/version.rb
@@ -1,7 +1,3 @@
 module MoxiworksPlatform
-<<<<<<< Updated upstream
-  VERSION = '0.13.14'
-=======
   VERSION = '0.13.15'
->>>>>>> Stashed changes
 end


### PR DESCRIPTION
This is a quick PR for issue https://github.com/moxiworks-platform/moxiworks-ruby/issues/12. Should just bring the gem in line with the docs which say you can use either moxi_works_agent_id or agent_uuid when searching for a contact.

I was having trouble getting specs to run locally, so I can't speak to those, but it seems like a pretty straight forward change.