### PR TITLE
add attr_accessor for Agent agent_uuid attribute

### DIFF
--- a/lib/moxiworks_platform/agent.rb
+++ b/lib/moxiworks_platform/agent.rb
@@ -27,6 +27,10 @@ module MoxiworksPlatform
     # @return [String] the UUID of the Agent
     attr_accessor :agent_id
 
+    # @!attribute string agent_uuid
+    #
+    # @return [String] the UUID of the Agent, equals :uuid attribute, needed for mapping Agent Index response with timestamps_only: true
+    attr_accessor :agent_uuid
 
     # @!attribute string office_id
     #
@@ -246,10 +250,10 @@ module MoxiworksPlatform
     #
     # @return [String] whether the agent has access to MoxiWorks Engage
     attr_accessor :has_engage_access
-    
+
     # @!attribute access_level
     #
-    # @return [String] The access level of the agent. 
+    # @return [String] The access level of the agent.
     # If include_access_level was passed as true, this can return one of the possible access levels: company-admin, manager, office-admin, office-owner, region-admin, user.
     attr_accessor :access_level
 

--- a/lib/moxiworks_platform/version.rb
+++ b/lib/moxiworks_platform/version.rb
@@ -1,3 +1,3 @@
 module MoxiworksPlatform
-  VERSION = '0.13.19'
+  VERSION = '0.13.20'
 end


### PR DESCRIPTION
Add attr_accessor  for Agent#agent_uuid attribute, for mappings Agents index response with `timestamps_only: true` flag.
```
 "agents": [
        {
            "agent_uuid": "uuid",
            "last_updated": 1703613715,
            "modification_timestamp": "2022-12-22T12:42:12.000+00:00"
        },
```
Made by MAXA Designs team